### PR TITLE
Pass additional parameters into ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Remove the object under the hash specified in the first argument from the pool.
 
     Chusha.share(new MyObject());
     Chusha.unshare('MyObject'); // Cancel the above statement.
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Then, to grab a new object:
     var obj = Chusha.get(MyObject);
     // obj now contains an instantiated MyObject instance with the HttpClient injected.
 
+To pass additional parameters into a constructor:
+
+    var HttpClient = require('./lib/HttpClient');
+
+    function MultiObject(http, server) {
+        this.http = http;
+        this.server = server;
+    }
+    MultiObject.inject = function() { return [HttpClient]; }
+
+    var obj = Chusha.get(MultiObject, "server-url");
+    // obj now contains an instantiated MultiObject instance with the HttpClient and server URL injected.
+
 ## Dependency sharing
 
 Sometimes, you'd want to share the same instance throughout all objects that need it (Database connection handlers, HTTP clients, etc).

--- a/src/chusha.js
+++ b/src/chusha.js
@@ -17,7 +17,7 @@ export class Chusha {
         let dependencyConstructors = Constructor.inject ? (Constructor.inject() || []) : [];
         let dependencies = dependencyConstructors.map(el => Chusha.get(el));
         let obj = Object.create(Constructor.prototype);
-	let params = dependencies.concat(args);
+        let params = dependencies.concat(args);
         Constructor.apply(obj, params);
 
         return obj;

--- a/src/chusha.js
+++ b/src/chusha.js
@@ -5,7 +5,7 @@ export class Chusha {
         this.sharePool = {};
     }
 
-    static get(Constructor) {
+    static get(Constructor, ...args) {
         if (Constructor.constructor.name === 'Object') {
             // You passed an already instantiated object and not a constructor.
             // Inject it directly.
@@ -17,7 +17,8 @@ export class Chusha {
         let dependencyConstructors = Constructor.inject ? (Constructor.inject() || []) : [];
         let dependencies = dependencyConstructors.map(el => Chusha.get(el));
         let obj = Object.create(Constructor.prototype);
-        Constructor.apply(obj, dependencies);
+	let params = dependencies.concat(args);
+        Constructor.apply(obj, params);
 
         return obj;
     }

--- a/src/chusha.js
+++ b/src/chusha.js
@@ -42,3 +42,4 @@ export class Chusha {
 if (typeof(window) !== 'undefined') {
     window.Chusha = Chusha;
 }
+

--- a/test/chushaTest.js
+++ b/test/chushaTest.js
@@ -62,3 +62,4 @@ describe('Chusha Dependency Injector', () => {
         (logger.b).should.equal(3);
     });
 });
+

--- a/test/chushaTest.js
+++ b/test/chushaTest.js
@@ -36,4 +36,29 @@ describe('Chusha Dependency Injector', () => {
         (() => { Chusha.share(['array']); }).should.throw(err);
         (() => { Chusha.share({'object': 'object'}); }).should.throw(err);
     });
+
+    it('should pass params on to the constructor', () => {
+        function OtherCtor(foo) {
+            this.foo = foo;
+        }
+
+        function LoggingCtor(other, a, b) {
+            this.foo = other.foo;
+            this.a = a;
+            this.b = b;
+        }
+
+        LoggingCtor.inject = function () {
+            return [OtherCtor];
+        }
+
+        var other = new OtherCtor(1);
+        Chusha.share(other, "OtherCtor");
+
+        var logger = Chusha.get(LoggingCtor, 2, 3); 
+
+        (logger.foo).should.equal(1);
+        (logger.a).should.equal(2);
+        (logger.b).should.equal(3);
+    });
 });


### PR DESCRIPTION
I think (just my opinion) it would be useful to be able to pass additional, not-injected parameters into the constructor while performing a `Chusha.get` for an instantiated object. This is a common pattern in most DI libraries I've used, and while it is slightly more difficult without annotations, is often useful.

The changes are very simple, should have minimal performance impact, and have an additional test to verify they work.
